### PR TITLE
Remove medium logo from navbar

### DIFF
--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -53,9 +53,6 @@ function Footer() {
 					>
 						<Icon icon={faLinkedin} />
 					</a>
-					<a href="https://www.medium.com/@hackthehill" target="_blank" rel="noreferrer" aria-label="Medium">
-						<Icon icon={faMedium} />
-					</a>
 				</div>
 			</div>
 			<div className="FooterText">

--- a/src/components/NavBar/Sidebar.jsx
+++ b/src/components/NavBar/Sidebar.jsx
@@ -106,9 +106,6 @@ export default function Sidebar() {
 					>
 						<Icon icon={faLinkedin} />
 					</a>
-					<a href="https://www.medium.com/@hackthehill" target="_blank" rel="noreferrer" aria-label="Medium">
-						<Icon icon={faMedium} />
-					</a>
 				</div>
 			</Menu>
 		</div>


### PR DESCRIPTION
Don't know what the logo in the navbar is referring to, but the Medium logo was removed from the Footer and Sidebar JSX files.