### PR TITLE
feat: add inline Hero email subscription

### DIFF
--- a/src/components/Hero/Hero.module.css
+++ b/src/components/Hero/Hero.module.css
@@ -357,27 +357,62 @@
 
 .hero-form {
 	display: flex;
-	gap: 0.75rem;
-	flex-wrap: wrap;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: 0.4rem;
 	justify-content: flex-start;
+	width: 100%;
+	max-width: 100%;
+	min-width: 0;
+	box-sizing: border-box;
 	margin-top: clamp(0.4rem, 1.2vh, 1rem);
 	/* Re-enable hits for the interactive controls (parent is pointer-events:none). */
 	pointer-events: auto;
 }
 
-/* Optimistic confirmation shown in place of the form after submit. */
+.hero-form-controls {
+	display: flex;
+	gap: 0.75rem;
+	flex-wrap: wrap;
+	justify-content: flex-start;
+	width: 100%;
+	min-width: 0;
+	box-sizing: border-box;
+	max-width: 100%;
+}
+
+.hero-form-error {
+	max-width: 34rem;
+	margin: 0;
+	font-family: Rubik, sans-serif;
+	font-size: clamp(0.7rem, 1.7vmin, 0.85rem);
+	line-height: 1.3;
+	text-shadow: 0 1px 6px rgba(251, 236, 183, 0.7);
+	color: var(--dark-secondary-color);
+	font-weight: 500;
+}
+
+.hero-visually-hidden {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border: 0;
+}
+
+/* Confirmation shown in place of the form after the request is accepted. */
 .hero-form-thanks {
 	margin: clamp(0.4rem, 1.2vh, 1rem) 0 0;
 	color: var(--dark-primary-color);
 	font-family: Coolvetica;
 	font-weight: 500;
 	font-size: clamp(1rem, 2.6vmin, 1.4rem);
+	line-height: 1.25;
 	text-shadow: 0 1px 8px rgba(251, 236, 183, 0.7);
-}
-
-/* Off-screen iframe that receives the signup GET so the page doesn't navigate. */
-.tracker-sink {
-	display: none;
 }
 
 .hero-btn {
@@ -397,6 +432,17 @@
 .hero-btn:hover {
 	transform: translateY(-2px);
 	box-shadow: 0 10px 24px rgba(132, 1, 11, 0.28);
+}
+
+.hero-btn:disabled,
+.hero-input:disabled {
+	cursor: wait;
+	opacity: 0.7;
+}
+
+.hero-btn:disabled:hover {
+	transform: none;
+	box-shadow: 0 6px 18px rgba(132, 1, 11, 0.2);
 }
 
 .hero-btn-icon {
@@ -509,6 +555,24 @@
 		--logo-w: clamp(180px, 56vw, 300px);
 	}
 
+	.hero-form-controls {
+		flex-wrap: nowrap;
+		gap: 0.5rem;
+		width: 100%;
+		min-width: 0;
+	}
+
+	.hero-input {
+		box-sizing: border-box;
+		min-width: 0;
+		width: auto;
+		flex: 1 1 auto;
+	}
+
+	.hero-btn {
+		flex: 0 0 auto;
+	}
+
 	.countdown-dialog {
 		display: none;
 	}
@@ -576,12 +640,18 @@
 	}
 
 	.hero-form {
-		flex-wrap: nowrap;
-		gap: 0.4rem;
 		margin-top: 0.2rem;
 		width: 100%;
 		min-width: 0;
 		max-width: 100%;
+		box-sizing: border-box;
+	}
+
+	.hero-form-controls {
+		flex-wrap: nowrap;
+		gap: 0.4rem;
+		width: 100%;
+		min-width: 0;
 		box-sizing: border-box;
 	}
 
@@ -635,12 +705,29 @@
 		margin-top: 0.2rem;
 	}
 
+	.hero-form-controls {
+		flex-wrap: nowrap;
+		gap: 0.4rem;
+		width: 100%;
+		min-width: 0;
+	}
+
 	.hero-input {
-		padding: 0.75rem;
+		box-sizing: border-box;
+		min-width: 0;
+		width: auto;
+		flex: 1 1 auto;
+		padding: 0.65rem;
+		font-size: 0.82rem;
 	}
 
 	.hero-btn {
-		padding: 0.65rem;
-		font-size: 1rem;
+		flex: 0 0 auto;
+		padding: 0.55rem 0.65rem;
+		font-size: 0.88rem;
+	}
+
+	.hero-form-error {
+		font-size: 0.68rem;
 	}
 }

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -1,6 +1,6 @@
 import { faArrowRight } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon as Icon } from "@fortawesome/react-fontawesome";
-import { useEffect, useState, useRef } from "react";
+import { type FormEvent, useEffect, useState, useRef } from "react";
 import { t } from "@/i18n";
 import styles from "./Hero.module.css";
 import "./animations.css";
@@ -10,6 +10,9 @@ import AOS from "aos";
 import "aos/dist/aos.css";
 
 const BannerLogo = "/Logos/hackthehill-banner.svg";
+const SUBSCRIBE_ENDPOINT = "https://emails.hackthehill.com/subscribe";
+
+type SubscriptionState = "idle" | "submitting" | "accepted" | "invalid" | "rate-limited" | "failed";
 
 const EVENT_START_DATE = new Date("2026-09-25T17:00:00-04:00").getTime();
 const HACKING_START_DATE = new Date("2026-09-25T23:00:00-04:00").getTime();
@@ -63,7 +66,9 @@ const clouds = [
 function Hero() {
 	const [popupOpen, setPopupOpen] = useState(false);
 	const [time, setTime] = useState(0);
-	const [submitted, setSubmitted] = useState(false);
+	const [email, setEmail] = useState("");
+	const [subscriptionState, setSubscriptionState] = useState<SubscriptionState>("idle");
+	const submittingRef = useRef(false);
 
 	useEffect(() => {
 		AOS.init();
@@ -86,12 +91,65 @@ function Hero() {
 	const formattedMinutes = minutes.toLocaleString("en-US", { minimumIntegerDigits: 2 });
 	const formattedSeconds = seconds.toLocaleString("en-US", { minimumIntegerDigits: 2 });
 
-	// `t()` calls React hooks internally, so the number of t() calls must stay
-	// constant across renders. The form/thanks branch below would otherwise vary
-	// the count, so resolve those strings up front (always called, every render).
+	// `t()` calls React hooks internally, so resolve all form strings up front and
+	// keep the number of calls constant across renders.
 	const emailPlaceholder = t("hero.email_placeholder");
+	const emailLabel = t("hero.email_label");
 	const followLabel = t("hero.more");
+	const sendingLabel = t("hero.sending");
 	const thanksLabel = t("hero.thanks");
+	const invalidEmailLabel = t("hero.invalid_email");
+	const rateLimitedLabel = t("hero.rate_limited");
+	const sendErrorLabel = t("hero.send_error");
+
+	const isSubmitting = subscriptionState === "submitting";
+	const errorLabel =
+		subscriptionState === "invalid"
+			? invalidEmailLabel
+			: subscriptionState === "rate-limited"
+				? rateLimitedLabel
+				: subscriptionState === "failed"
+					? sendErrorLabel
+					: null;
+
+	const handleSubscribe = async (event: FormEvent<HTMLFormElement>) => {
+		event.preventDefault();
+		if (submittingRef.current) return;
+
+		submittingRef.current = true;
+		setSubscriptionState("submitting");
+		try {
+			const response = await fetch(SUBSCRIBE_ENDPOINT, {
+				method: "POST",
+				headers: {
+					Accept: "application/json",
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({ email: email.trim(), consent: true }),
+			});
+
+			if (response.status === 202) {
+				setSubscriptionState("accepted");
+				return;
+			}
+
+			if (response.status === 400) {
+				setSubscriptionState("invalid");
+				return;
+			}
+
+			if (response.status === 429) {
+				setSubscriptionState("rate-limited");
+				return;
+			}
+
+			setSubscriptionState("failed");
+		} catch {
+			setSubscriptionState("failed");
+		} finally {
+			submittingRef.current = false;
+		}
+	};
 
 	// For parallax scrolling effect
 	const heroRef = useRef<HTMLDivElement>(null);
@@ -283,54 +341,62 @@ function Hero() {
 				<h2 data-aos="fade-up" data-aos-duration="800" data-aos-delay="200">
 					{t("hero.h2")}
 				</h2>
-				{/* The form submits a GET into the hidden iframe below, so the tracker
-				    records the follow without navigating the page away. It's a
-				    cross-origin navigation (not a fetch), so CORS doesn't apply — but
-				    we also can't read the result, hence the optimistic message. */}
-				{submitted ? (
-					<output className={styles["hero-form-thanks"]} data-aos="fade-up" aria-live="polite">
+				{subscriptionState === "accepted" ? (
+					<output className={styles["hero-form-thanks"]} data-aos="fade-up" aria-live="polite" role="status">
 						{thanksLabel}
 					</output>
 				) : (
 					<form
 						className={styles["hero-form"]}
-						action="https://tracker.hackthehill.com/follow"
-						target="tracker-sink"
-						onSubmit={() => setSubmitted(true)}
+						onSubmit={handleSubscribe}
+						aria-busy={isSubmitting}
 					>
-						<input
-							id="email"
-							name="email"
-							className={styles["hero-input"]}
-							type="email"
-							required
-							placeholder={emailPlaceholder}
-							data-aos="fade-up"
-							data-aos-duration="1000"
-							data-aos-delay="400"
-						/>
-						<button
-							type="submit"
-							className={styles["hero-btn"]}
-							data-aos="fade-up"
-							data-aos-duration="1000"
-							data-aos-delay="500"
-						>
-							{followLabel} <Icon icon={faArrowRight} className={styles["hero-btn-icon"]} />
-						</button>
+						<div className={styles["hero-form-controls"]}>
+							<label className={styles["hero-visually-hidden"]} htmlFor="email">
+								{emailLabel}
+							</label>
+							<input
+								id="email"
+								name="email"
+								className={styles["hero-input"]}
+								type="email"
+								required
+								maxLength={254}
+								autoComplete="email"
+								inputMode="email"
+								spellCheck={false}
+								value={email}
+								onChange={(event) => {
+									setEmail(event.target.value);
+									if (subscriptionState !== "idle") setSubscriptionState("idle");
+								}}
+								placeholder={emailPlaceholder}
+								disabled={isSubmitting}
+								aria-invalid={subscriptionState === "invalid"}
+								aria-describedby={errorLabel ? "email-error" : undefined}
+								data-aos="fade-up"
+								data-aos-duration="1000"
+								data-aos-delay="400"
+							/>
+							<button
+								type="submit"
+								className={styles["hero-btn"]}
+								disabled={isSubmitting}
+								data-aos="fade-up"
+								data-aos-duration="1000"
+								data-aos-delay="500"
+							>
+								{isSubmitting ? sendingLabel : followLabel}
+								{!isSubmitting && <Icon icon={faArrowRight} className={styles["hero-btn-icon"]} />}
+							</button>
+						</div>
+						{errorLabel && (
+							<p id="email-error" className={styles["hero-form-error"]} role="alert">
+								{errorLabel}
+							</p>
+						)}
 					</form>
 				)}
-				{/* Hidden submit target — keeps the follow request on this page.
-				    Hide inline (not just via the CSS class) so the iframe never flashes
-				    at its default 300×150 bordered box before the stylesheet loads. */}
-				<iframe
-					className={styles["tracker-sink"]}
-					style={{ display: "none" }}
-					name="tracker-sink"
-					title="Newsletter signup"
-					tabIndex={-1}
-					aria-hidden="true"
-				/>
 			</div>
 
 			{/* Popup for countdown when opening the clock-tower hotspot */}

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -13,11 +13,16 @@ export default {
 	hero: {
 		at: "@",
 		h2: "Canada's Capital Hackathon",
-		more: "Follow us!",
+		more: "Get updates",
 		email_placeholder: "E-mail",
+		email_label: "Email address",
+		sending: "Sending…",
 		apply: "Apply Now",
 		date: "Sept. 25-27, 2026",
-		thanks: "Thanks! Keep an eye on your inbox.",
+		thanks: "Check your inbox for a confirmation link.",
+		invalid_email: "Enter a valid email.",
+		rate_limited: "Try again shortly.",
+		send_error: "Couldn’t subscribe. Try again.",
 	},
 	about: {
 		title: "Welcome to Hack the Hill III",

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -13,11 +13,16 @@ export default {
 	hero: {
 		at: "à",
 		h2: "Le Hackathon de la Capitale Canadienne",
-		more: "Suivez-nous!",
+		more: "Recevoir les nouvelles",
 		email_placeholder: "Courriel",
+		email_label: "Adresse courriel",
+		sending: "Envoi…",
 		apply: "Appliquez Maintenant",
 		date: "25-27 Sept. 2026",
-		thanks: "Merci! Surveillez votre boîte de réception.",
+		thanks: "Vérifiez vos courriels pour confirmer.",
+		invalid_email: "Saisissez un courriel valide.",
+		rate_limited: "Réessayez dans un instant.",
+		send_error: "Inscription impossible. Réessayez.",
 	},
 	about: {
 		title: "Bienvenue à Hack the Hill III",


### PR DESCRIPTION
## Summary
- replace the tracker iframe with an inline POST to the email list service
- add loading, accepted, validation, rate-limit, and failure states
- simplify Hero signup copy and add responsive, accessible form styles